### PR TITLE
Add vagrant, automatically bring up environment with MongoDB, nodeJS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ public
 
 *.DS_Store
 config*.json
+.vagrant

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,19 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+
+  # Every Vagrant virtual environment requires a box to build off of.
+  config.vm.box_url = "http://files.vagrantup.com/precise64.box"
+  config.vm.box = "precise64"
+
+  config.vm.network "forwarded_port", guest: 27017, host: 27017
+  config.vm.network "forwarded_port", guest: 3000, host: 3000
+
+  config.vm.provision "ansible" do |ansible|
+    ansible.playbook = "provision/setup.yml"
+  end
+end

--- a/provision/handlers/handlers.yml
+++ b/provision/handlers/handlers.yml
@@ -1,0 +1,6 @@
+- name: mongodb-start
+  service: name=mongodb state=started  
+- name: mongodb-restart
+  service: name=mongodb state=restarted
+- name: mongodb-reload
+  service: name=mongodb state=reloaded

--- a/provision/setup.yml
+++ b/provision/setup.yml
@@ -1,0 +1,12 @@
+---
+- hosts: all
+  user: vagrant
+  sudo: True
+  vars:
+    repository_basedir: ..
+  tasks:
+    - include: "{{repository_basedir}}/provision/tasks/base-packages.yml"
+    - include: "{{repository_basedir}}/provision/tasks/mongodb.yml"
+    - include: "{{repository_basedir}}/provision/tasks/dos.yml"
+  handlers:
+    - include: "{{repository_basedir}}/provision/handlers/handlers.yml"

--- a/provision/tasks/base-packages.yml
+++ b/provision/tasks/base-packages.yml
@@ -1,0 +1,17 @@
+- name: Install 'python-apt' module (Ubuntu)
+  command: apt-get install python-apt -y
+- name: ensure packages required are installed
+  apt: pkg={{ item }} state=present
+  with_items:
+    - build-essential
+    - bc
+    - flex
+    - unzip
+    - patch
+    - make
+    - bzip2
+    - autoconf
+    - automake
+    - libtool
+    - git
+    - python-pycurl

--- a/provision/tasks/dos.yml
+++ b/provision/tasks/dos.yml
@@ -1,0 +1,6 @@
+- name: DemocracyOS | Add Node PPA
+  apt_repository: repo='ppa:chris-lea/node.js'
+- name: DemocracyOS | Install NodeJS
+  apt: pkg=nodejs update_cache=yes state=present
+- name: DemocracyOS | Install packages
+  npm: path=/vagrant

--- a/provision/tasks/mongodb.yml
+++ b/provision/tasks/mongodb.yml
@@ -1,0 +1,20 @@
+- name: MongoDB | Fetch 10Gen signing key
+  command: apt-key adv --keyserver keyserver.ubuntu.com --recv 7F0CEB10
+- name: MongoDB | Add 10Gen repository
+  shell:
+    echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' | sudo tee /etc/apt/sources.list.d/10gen.list
+    creates=/etc/apt/sources.list.d/10gen.list
+- name: MongoDB | Install latest MongoDB release
+  apt: pkg=mongodb-10gen state=present update_cache=yes
+- name: MongoDB | Creates DB directory
+  file: path=/data/db state=directory group=mongodb owner=mongodb
+- name: MongoDB | Push default configuration template
+  template:
+    src="{{repository_basedir}}/provision/templates/mongodb.conf"
+    dest=/etc/mongodb.conf
+    owner=root group=root mode=0644
+  notify:
+  - mongodb-restart
+# Ensure service is running.
+- name: MongoDB | Ensure deamon is running correctly
+  service: name=mongodb state=started

--- a/provision/templates/mongodb.conf
+++ b/provision/templates/mongodb.conf
@@ -1,0 +1,1 @@
+dbpath = /data/db


### PR DESCRIPTION
This PR includes a Vagrantfile, which will bring up a VM that has MongoDB, NodeJS and the node modules installed.

To use:

1. `vagrant up`
2. `vagrant ssh`
3.  `cd /vagrant`
4. `make`

You can then open http://127.0.0.1:3000 on your host.