### PR TITLE
Notifier wrapper. Closes #560

### DIFF
--- a/lib/db-api/comment.js
+++ b/lib/db-api/comment.js
@@ -17,7 +17,7 @@ var config = require('lib/config');
 var t = require('t-component');
 var log = require('debug')('democracyos:db-api:comment');
 var config = require('lib/config');
-var notifier = require('notifier-client')(config.notifications);
+var notifier = require('lib/notifications');
 var url = require('url');
 
 /**

--- a/lib/forgot-api/lib/forgotpassword.js
+++ b/lib/forgot-api/lib/forgotpassword.js
@@ -8,7 +8,7 @@ var api = require('lib/db-api');
 var t = require('t-component');
 var config = require('lib/config');
 var url = require('url');
-var notifier = require('notifier-client')(config.notifications);
+var notifier = require('lib/notifications');
 
 var Citizen = mongoose.model('Citizen');
 

--- a/lib/law-api/index.js
+++ b/lib/law-api/index.js
@@ -12,7 +12,7 @@ var pluck = utils.pluck;
 var expose = utils.expose;
 var log = require('debug')('democracyos:law');
 var config = require('lib/config');
-var notifier = require('notifier-client')(config.notifications);
+var notifier = require('lib/notifications');
 var url = require('url');
 
 var app = module.exports = express();

--- a/lib/notifications/index.js
+++ b/lib/notifications/index.js
@@ -1,0 +1,36 @@
+var config = require('lib/config');
+var notifier = require('notifier-client')(config.notifications);
+var utils = require('lib/utils');
+var t = require('t-component');
+var log = require('debug')('democracyos:notifications');
+
+exports.makeSafe = function makeSafe(fn, errorHandler) {
+  if ('function' === typeof fn) throw new Error('Attempted to make safe something that isn\'t a function');
+
+  return function () {
+    try {
+      return fn.apply(this, arguments);
+    } catch(err) {
+      if ('function' === typeof errorHandler) return errorHandler(err);
+      else throw err;
+    }
+  };
+};
+
+var originalSend = notifier.send.bind(notifier);
+
+notifier.send = function sendWrapper (callback) {
+
+  log('Attempting to send wrapped notification');
+  originalSend(function (err, res) {
+    if (err && err.code == 'ECONNREFUSED') {
+
+      log('Unable to send notification - Error: %j', err);
+      err.message = t('notifications.error.connection-refused');
+    }
+
+    callback(err, res);
+  });
+};
+
+module.exports = notifier;

--- a/lib/notifications/index.js
+++ b/lib/notifications/index.js
@@ -1,31 +1,15 @@
 var config = require('lib/config');
 var notifier = require('notifier-client')(config.notifications);
-var utils = require('lib/utils');
 var t = require('t-component');
 var log = require('debug')('democracyos:notifications');
-
-exports.makeSafe = function makeSafe(fn, errorHandler) {
-  if ('function' === typeof fn) throw new Error('Attempted to make safe something that isn\'t a function');
-
-  return function () {
-    try {
-      return fn.apply(this, arguments);
-    } catch(err) {
-      if ('function' === typeof errorHandler) return errorHandler(err);
-      else throw err;
-    }
-  };
-};
 
 var originalSend = notifier.send.bind(notifier);
 
 notifier.send = function sendWrapper (callback) {
-
-  log('Attempting to send wrapped notification');
   originalSend(function (err, res) {
     if (err && err.code == 'ECONNREFUSED') {
 
-      log('Unable to send notification - Error: %j', err);
+      log('Unable connect to the notifier server - Error: %j', err);
       err.message = t('notifications.error.connection-refused');
     }
 

--- a/lib/notifications/index.js
+++ b/lib/notifications/index.js
@@ -1,20 +1,24 @@
+/**
+ * Module dependencies.
+ */
+
 var config = require('lib/config');
-var notifier = require('notifier-client')(config.notifications);
+var Notifier = require('notifier-client');
 var t = require('t-component');
 var log = require('debug')('democracyos:notifications');
 
-var originalSend = notifier.send.bind(notifier);
+var originalSend = Notifier.prototype.send;
 
-notifier.send = function sendWrapper (callback) {
-  originalSend(function (err, res) {
+Notifier.prototype.send = function sendWrapper (callback) {
+  originalSend.call(this, function (err, res) {
     if (err && err.code == 'ECONNREFUSED') {
 
       log('Unable connect to the notifier server - Error: %j', err);
-      err.message = t('notifications.error.connection-refused');
+      err = t('notifications.error.connection-refused');
     }
 
     callback(err, res);
   });
 };
 
-module.exports = notifier;
+module.exports = new Notifier(config.notifications);

--- a/lib/signup-api/lib/signup.js
+++ b/lib/signup-api/lib/signup.js
@@ -9,7 +9,7 @@ var api = require('lib/db-api');
 var t = require('t-component');
 var config = require('lib/config');
 var url = require('url');
-var notifier = require('notifier-client')(config.notifications);
+var notifier = require('lib/notifications');
 
 var Citizen = mongoose.model('Citizen');
 

--- a/lib/translations/lib/ca.json
+++ b/lib/translations/lib/ca.json
@@ -53,6 +53,8 @@
   "settings.notificatoins.someone-replies-your-comments": "Algú respon a un dels seus comentaris",
   "settings.notifications.someone-mentions-in-their-comment": "Algú li esmenta en un dels seus comentaris",
 
+  "notifications.error.connection-refused": "No es pot connectar al motor de notificacions",
+
   "validators.required": "cal",
   "validators.checked": "Camp obligatori comprovat",
   "validators.invalid.email": "Adreça de correu electrònic no és vàlid",

--- a/lib/translations/lib/de.json
+++ b/lib/translations/lib/de.json
@@ -47,6 +47,8 @@
   "Current password is invalid": "Passwort ungültig",
   "More information": "weitere Informationen",
 
+  "notifications.error.connection-refused": "Unfähig, um Benachrichtigungen Motor verbinden",
+
   "sidebar.open": "Offen",
   "sidebar.closed": "Geschlossen",
   "sidebar.hide-voted": "Meine Entscheidungen verbergen",

--- a/lib/translations/lib/en.json
+++ b/lib/translations/lib/en.json
@@ -52,6 +52,8 @@
   "settings.notifications.new-topic": "A new topic gets published",
   "settings.notificatoins.someone-replies-your-comments": "Someone replies one of your comments",
 
+  "notifications.error.connection-refused": "Unable to connect to notifications engine",
+
   "validators.required": "Required",
   "validators.checked": "Required checked field",
   "validators.invalid.email": "Invalid email address",

--- a/lib/translations/lib/es.json
+++ b/lib/translations/lib/es.json
@@ -54,6 +54,8 @@
   "someone-mentions-in-their-comment": "Eres mencionado en algún argumento",
   "settings.notificatoins.someone-replies-your-comments": "Alguien contesta uno de tus argumentos",
 
+  "notifications.error.connection-refused": "No es posible conectarse al motor de notificaciones",
+
   "validators.required": "Requerido",
   "validators.checked": "Elegir una opción",
   "validators.invalid.email": "El e-mail no es válido",

--- a/lib/translations/lib/fi.json
+++ b/lib/translations/lib/fi.json
@@ -53,6 +53,8 @@
   "settings.notificatoins.someone-replies-your-comments": "Joku vastaa yksi teidän kommentteja",
   "settings.notifications.someone-mentions-in-their-comment": "Joku mainitsee sinut yhdessä huomautuksensa",
 
+  "notifications.error.connection-refused": "Yhteyttä ilmoitukset moottori",
+
   "validators.required": "vaadittu",
   "validators.checked": "Vaadittu tarkastetaan kenttä",
   "validators.invalid.email": "Virheellinen sähköpostiosoite",

--- a/lib/translations/lib/fr.json
+++ b/lib/translations/lib/fr.json
@@ -53,6 +53,8 @@
   "settings.notificatoins.someone-replies-your-comments": "Quelqu'un répond l'un de vos commentaires",
   "settings.notifications.someone-mentions-in-their-comment": "Quelqu'un vous parle dans un de leurs commentaires",
 
+  "notifications.error.connection-refused": "Impossible de se connecter au moteur de notifications",
+
   "validators.required": "requis",
   "validators.checked": "Exiger champ vérifié",
   "validators.invalid.email": "Adresse mail invalide",

--- a/lib/translations/lib/it.json
+++ b/lib/translations/lib/it.json
@@ -53,6 +53,8 @@
   "settings.notificatoins.someone-replies-your-comments": "Qualcuno risponde uno dei tuoi commenti",
   "settings.notifications.someone-mentions-in-their-comment": "Qualcuno ti cita in una delle loro osservazioni",
 
+  "notifications.error.connection-refused": "Impossibile connettersi al motore notifiche",
+
   "validators.required": "Obbligatorio",
   "validators.checked": "Campo controllato obbligatori",
   "validators.invalid.email": "Indirizzo email non valido",

--- a/lib/translations/lib/nl.json
+++ b/lib/translations/lib/nl.json
@@ -46,6 +46,8 @@
   "Current password is invalid": "Huidig wachtwoord is niet correct",
   "More information": "meer informatie",
 
+  "notifications.error.connection-refused": "Kan geen verbinding maken met meldingen motor",
+
   "sidebar.open": "Open",
   "sidebar.closed": "Gesloten",
   "sidebar.hide-voted": "Verberg mijn eigen stemmen",

--- a/lib/translations/lib/pt.json
+++ b/lib/translations/lib/pt.json
@@ -46,6 +46,8 @@
   "Current password is invalid": "Senha atual inválida",
   "Please wait": "Please wait",
 
+  "notifications.error.connection-refused": "Não é possível conectar a notificações motor",
+
   "validators.required": "Required",
   "validators.checked": "Required checked field",
   "validators.invalid.email": "Invalid email address",


### PR DESCRIPTION
Provides a wrapper for `notifier-client` in the way of a simple decorator that wraps the `send` function and intercepts the low-level `ECONNREFUSED` error triggered when the `notifier` server is unreachable by the client and provides a higher level error with a localized text entry.

Whether the backend should answer with `200` or `500` for these cases is not clear to me; sometimes (`signin`) the response is `200` and some other times `forgot` it's `500`; I believe we should establish one single approach.

Client-side handling of errors caused by notifier being unreachable are out of scope for this PR.