### PR TITLE
Fix/build process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,14 @@ packages:
 	@echo "Installing dependencies..."
 	@npm install
 	@echo "Done.\n"
+	@echo "Installing components..."
+	@DEBUG=$(DEBUG) node ./bin/dos-install --config
+	@echo "Updating config settings..."
+	@DEBUG=$(DEBUG) node ./bin/dos-config
+	@echo "Done.\n"
+	@echo "Compiling components to ./public..."
+	@DEBUG=$(DEBUG) node ./bin/dos-build
+	@echo "Done.\n"
 
 clean:
 	@echo "Removing dependencies, components and built assets."

--- a/Makefile
+++ b/Makefile
@@ -17,15 +17,6 @@ run: packages
 packages:
 	@echo "Installing dependencies..."
 	@npm install
-	@echo "Done.\n"
-	@echo "Installing components..."
-	@DEBUG=$(DEBUG) node ./bin/dos-install --config
-	@echo "Updating config settings..."
-	@DEBUG=$(DEBUG) node ./bin/dos-config
-	@echo "Done.\n"
-	@echo "Compiling components to ./public..."
-	@DEBUG=$(DEBUG) node ./bin/dos-build
-	@echo "Done.\n"
 
 clean:
 	@echo "Removing dependencies, components and built assets."

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: node index.js
+web: node ./bin/dos-install && node ./bin/dos-config && node ./bin/dos-build && node index.js

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: node ./bin/dos-install && node ./bin/dos-config && node ./bin/dos-build && node index.js
+web: DEBUG=$(DEBUG) node index.js

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: DEBUG=$(DEBUG) node index.js
+web: node index.js

--- a/bin/dos-build
+++ b/bin/dos-build
@@ -4,15 +4,21 @@
  * Module dependencies.
  */
 
-var fs = require('fs');
-var write = fs.writeFileSync;
 var path = require('path');
 var resolve = path.resolve;
+var fs = require('fs');
+var write = fs.writeFileSync;
 
 // Little hack to include `NODE_PATH=.`
 require('node-path')(module, [resolve('.')]);
 
 
 // Compile client application `./public/app.js` and `./public/app.css`
-var build = require('lib/build');
-build();
+var Builder = require('lib/build');
+
+Builder.build(function(err, res) {
+  if (err) return console.log(err), process.exit(1);
+
+  write('public/app.js', res.js);
+  write('public/app.css', res.css);
+});

--- a/lib/build/index.js
+++ b/lib/build/index.js
@@ -8,16 +8,16 @@ var stylus = require('./stylus');
 var fs = require('fs');
 var write = fs.writeFileSync;
 var log = require('debug')('democracyos:build');
-var mkdir = require('mkdirp');
 var resolve = require('component-resolver');
 var jade = require('builder-jade');
+var Batch = require('batch');
 
 /**
  * Expose component
  * builder getter
  */
 
-module.exports = build;
+module.exports.build = build;
 
 /**
  * Expose component
@@ -27,49 +27,75 @@ module.exports = build;
 module.exports.middleware = middleware;
 
 /**
- * Creates a `Builder` instance
+ * Creates a `build` instance
  * ready for build
  */
 
-function build(next) {
-  resolve(process.cwd(), {
-    // install the remote components locally
+function build(done) {
+  log('Start assets compilation')
+
+  var options = {
     install: false,
     root: 'public'
-  }, function (err, tree) {
-    if (err) console.log(err), process.exit(1);
+  };
 
-    mkdir('public');
+  resolve(process.cwd(), options, onresolve);
 
-    builder.scripts(tree)
-      .use('scripts', builder.plugins.js())
-      .use('json', builder.plugins.json())
-      .use('templates', jade({
-        string: false,
-        runtime: true
-      }))
-      .use('templates', builder.plugins.string())
-      .end(function (err, js) {
-        if (err) throw err;
-        write('public/app.js', builder.scripts.require + jade.runtime + js);
-      });
+  function onresolve(err, tree) {
+    if (err) return log('Found error resolving dependencies tree %s', err), done(err);
 
-    builder.styles(tree)
-      .use('styles', builder.plugins.css())
-      .use('styles', stylus())
-      .use('styles', builder.plugins.urlRewriter(''))
-      .end(function (err, string) {
-        if (err) throw err;
-        fs.writeFileSync('public/app.css', string);
-      });
+    var batch = new Batch();
+    batch.push(buildScripts);
+    batch.push(buildStyles);
+    batch.push(buildFiles);
 
-    builder.files(tree, {destination: 'public'})
-      .use('images', builder.plugins.copy())
-      .use('files', builder.plugins.copy())
-      .end();
+    batch.end(function (err, results) {
+      if (err) return log('Found error compiling assets: %s', err), done(err);
 
-    if (next) return next();
-  })
+      log('Done compiling assets');
+      var res = {};
+      res.js = results[0];
+      res.css = results[1];
+      done(null, res);
+    });
+
+    function buildScripts(done) {
+      builder.scripts(tree)
+        .use('scripts', builder.plugins.js())
+        .use('json', builder.plugins.json())
+        .use('templates', jade({
+          string: false,
+          runtime: true
+        }))
+        .use('templates', builder.plugins.string())
+        .end(function (err, js) {
+          if (err) return log('Found error building scripts'), done(err);
+
+          return log('Scripts built successfully'), done(null, builder.scripts.require + jade.runtime + js);
+        });
+    }
+
+    function buildStyles(done) {
+      builder.styles(tree)
+        .use('styles', builder.plugins.css())
+        .use('styles', stylus())
+        .use('styles', builder.plugins.urlRewriter(''))
+        .end(function (err, css) {
+          if (err) return log('Found error building styles: %s', err), done(err);
+
+          return log('Styles built successfully'), done(null, css);
+        });
+    }
+
+    function buildFiles(done) {
+      builder.files(tree, {destination: 'public'})
+        .use('images', builder.plugins.copy())
+        .use('files', builder.plugins.copy())
+        .end(function () {
+          return log('Files copied successfully'), done();
+        });
+    }
+  }
 }
 
 /**
@@ -82,6 +108,12 @@ function middleware (req, res, next) {
     return next();
   };
 
-  log('Build %s.', req.path);
-  build(next);
+  build(function (err, res) {
+    if (err) return next(err);
+
+    log('Write script and stylesheet');
+    write('public/app.js', res.js);
+    write('public/app.css', res.css);
+    next();
+  });
 };

--- a/package.json
+++ b/package.json
@@ -101,5 +101,8 @@
   "engines": {
     "node": "0.10.28",
     "npm": "1.4.9"
+  },
+  "scripts": {
+    "postinstall": "node ./bin/dos-install --config && node ./bin/dos-config && node ./bin/dos-build"
   }
 }

--- a/package.json
+++ b/package.json
@@ -91,7 +91,8 @@
     "t-component": "1.0.0",
     "transliteration": "~0.1.1",
     "truncate": "~1.0.2",
-    "type-component": "0.0.1"
+    "type-component": "0.0.1",
+    "batch": "~0.5.2"
   },
   "devDependencies": {
     "google-translate": "^0.1.8"
@@ -100,9 +101,5 @@
   "engines": {
     "node": "0.10.28",
     "npm": "1.4.9"
-  },
-  "scripts": {
-    "test": "",
-    "postinstall": "node ./bin/dos-install --config && node ./bin/dos-config && node ./bin/dos-build"
   }
 }


### PR DESCRIPTION
Builder is now given a callback function like this:
```
function (err, res) {
  // err contains the first error occurred during build process, or else is null
  // res.js contains a string with the require js library followed by all the resulting app scripts
  // res.css contains a string with all the resulting app styles
}
```
This callback is called upon building scripts, stylesheets and copying assets to `public` directory

If an error is present, the build process exits with `process.exit(1)` telling heroku to retry the build