### PR TITLE
add debugging configurations for client

### DIFF
--- a/config/sample.json
+++ b/config/sample.json
@@ -25,7 +25,7 @@
     "pp",
     "glossary",
     "authPages",
-    "debugging"
+    "client debug"
   ],
   "auth": {
     "basic": {
@@ -69,9 +69,6 @@
     "redirect": "normal"
   },
   "multicore": false,
-  "debugging": {
-    "server": false,
-    "client": false
-  },
+  "client debug": false,
   "googleAPIKey": ""
 }

--- a/config/sample.json
+++ b/config/sample.json
@@ -24,7 +24,8 @@
     "tos",
     "pp",
     "glossary",
-    "authPages"
+    "authPages",
+    "debugging"
   ],
   "auth": {
     "basic": {
@@ -68,5 +69,9 @@
     "redirect": "normal"
   },
   "multicore": false,
+  "debugging": {
+    "server": false,
+    "client": false
+  },
   "googleAPIKey": ""
 }

--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ var launch = function launchServer () {
         log('Secure application started on port %d', securePort);
       });
     }
-  }
+  };
 
 /**
  * Launch the servers

--- a/lib/404/component.json
+++ b/lib/404/component.json
@@ -6,10 +6,10 @@
     "component/dom": "1.0.6",
     "visionmedia/page.js": "1.3.7",
     "jadejs/jade": "1.1.5",
-    "visionmedia/debug": "2.1.0",
     "yields/empty": "0.0.1"
   },
   "locals": [
+    "debug",
     "render"
   ],
   "styles": [ "styles.styl" ],

--- a/lib/admin-laws-form/component.json
+++ b/lib/admin-laws-form/component.json
@@ -6,7 +6,6 @@
     "component/dom": "1.0.6",
     "gvilarino/datepicker": "1.0.2",
     "gvilarino/timepicker": "1.1.2a",
-    "visionmedia/debug": "2.1.0",
     "jadejs/jade": "1.1.5",
     "visionmedia/page.js": "1.3.7",
     "yields/serialize": "0.2.0",
@@ -22,7 +21,8 @@
     "laws",
     "render",
     "request",
-    "regexps"
+    "regexps",
+    "debug"
   ],
   "templates": [
     "template.jade",

--- a/lib/admin/component.json
+++ b/lib/admin/component.json
@@ -7,7 +7,6 @@
     "component/classes": "1.2.0",
     "visionmedia/page.js": "1.3.7",
     "jadejs/jade": "1.1.5",
-    "visionmedia/debug": "2.1.0",
     "yields/empty": "0.0.1",
     "yields/serialize": "0.2.0",
     "slifszyc/query": "0.0.3"
@@ -24,7 +23,8 @@
     "tags",
     "request",
     "title",
-    "render"
+    "render",
+    "debug"
   ],
   "scripts": [ "admin.js" ],
   "styles": [ "admin.styl", "admin-wrappers.styl", "admin-heading.styl" ],

--- a/lib/autosubmit/component.json
+++ b/lib/autosubmit/component.json
@@ -3,11 +3,11 @@
   "description": "Autosubmit a form",
   "dependencies": {
     "component/dom": "1.0.6",
-    "visionmedia/debug": "2.1.0",
     "yields/serialize": "0.2.0"
   },
   "locals": [
-    "request"
+    "request",
+    "debug"
   ],
   "scripts": [ "autosubmit.js" ],
   "main": "autosubmit.js"

--- a/lib/autovalidate/component.json
+++ b/lib/autovalidate/component.json
@@ -3,10 +3,12 @@
   "description": "Component to validate form inputs and displaying messages on submit",
   "dependencies": {
     "component/dom": "1.0.6",
-    "visionmedia/debug": "2.1.0",
     "yields/serialize": "0.2.0"
   },
-  "locals": [ "validate" ],
+  "locals": [
+    "validate",
+    "debug"
+  ],
   "scripts": [ "autovalidate.js" ],
   "main": "autovalidate.js"
 }

--- a/lib/boot/boot.js
+++ b/lib/boot/boot.js
@@ -22,6 +22,15 @@ var translations = require('translations');
 var bus = require('bus');
 var ua = require('user-agent');
 var t = require('t');
+var debug = require('debug');
+
+if (config.debugging.client === true) {
+  debug.enable('democracyos:*');
+} else if ('string' === typeof config.debugging.client) {
+  debug.enable(config.debugging.client);
+} else {
+  debug.disable();
+}
 
 /**
  * Load localization dictionaries to translation application

--- a/lib/boot/boot.js
+++ b/lib/boot/boot.js
@@ -22,17 +22,12 @@ var translations = require('translations');
 var bus = require('bus');
 var ua = require('user-agent');
 var t = require('t');
-var debug = require('debug');
 
-if (config['client debug'] && true === config['client debug']) {
-  debug.disable();
-  debug.enable('democracyos:*');
-} else if (config['client debug'] && 'string' === typeof config['client debug']) {
-  debug.disable();
-  debug.enable(config['client debug']);
-} else {
-  debug.disable();
-}
+/**
+ * Initialize debug for DemocracyOS
+ */
+
+var log = require('debug')('democraycos:boot');
 
 /**
  * Load localization dictionaries to translation application
@@ -76,7 +71,7 @@ timeago('.ago', { lang: config['locale'], interval: 1000 });
  */
 
 page('*', function(ctx, next) {
-  console.log('Should render Not found.');
+  log('Should render Not found.');
 });
 
 /**

--- a/lib/boot/boot.js
+++ b/lib/boot/boot.js
@@ -24,10 +24,12 @@ var ua = require('user-agent');
 var t = require('t');
 var debug = require('debug');
 
-if (config.debugging.client === true) {
+if (config['client debug'] && true === config['client debug']) {
+  debug.disable();
   debug.enable('democracyos:*');
-} else if ('string' === typeof config.debugging.client) {
-  debug.enable(config.debugging.client);
+} else if (config['client debug'] && 'string' === typeof config['client debug']) {
+  debug.disable();
+  debug.enable(config['client debug']);
 } else {
   debug.disable();
 }

--- a/lib/boot/component.json
+++ b/lib/boot/component.json
@@ -7,8 +7,7 @@
     "component/bus": "^0.0.2",
     "DemocracyOS/timeago": "master",
     "code42day/ga": "1.1.0",
-    "slifszyc/user-agent": "0.0.9",
-    "visionmedia/debug": "2.1.0"
+    "slifszyc/user-agent": "0.0.9"
   },
   "locals": [
     "config",
@@ -28,7 +27,8 @@
     "logout",
     "help",
     "404",
-    "browser-update"
+    "browser-update",
+    "debug"
   ],
   "scripts": [ "boot.js" ],
   "styles": [ "boot.styl", "boot-responsive.styl" ],

--- a/lib/boot/component.json
+++ b/lib/boot/component.json
@@ -7,7 +7,8 @@
     "component/bus": "^0.0.2",
     "DemocracyOS/timeago": "master",
     "code42day/ga": "1.1.0",
-    "slifszyc/user-agent": "0.0.9"
+    "slifszyc/user-agent": "0.0.9",
+    "visionmedia/debug": "2.1.0"
   },
   "locals": [
     "config",

--- a/lib/boot/index.js
+++ b/lib/boot/index.js
@@ -8,6 +8,15 @@ var path = require('path');
 var translations = require('lib/translations');
 var t = require('t-component');
 var config = require('lib/config');
+var debug = require('debug');
+
+if (config.debugging.server === true) {
+  debug.enable('democracyos:*');
+} else if ('string' === typeof config.debugging.server) {
+  debug.enable(config.debugging.server);
+} else {
+  debug.disable();
+}
 
 
 /**

--- a/lib/boot/index.js
+++ b/lib/boot/index.js
@@ -8,15 +8,6 @@ var path = require('path');
 var translations = require('lib/translations');
 var t = require('t-component');
 var config = require('lib/config');
-var debug = require('debug');
-
-if (config.debugging.server === true) {
-  debug.enable('democracyos:*');
-} else if ('string' === typeof config.debugging.server) {
-  debug.enable(config.debugging.server);
-} else {
-  debug.disable();
-}
 
 
 /**

--- a/lib/citizen/component.json
+++ b/lib/citizen/component.json
@@ -5,10 +5,14 @@
     "component/bus": "^0.0.2",
     "component/emitter": "1.1.3",
     "component/emitter": "1.1.1",
-    "visionmedia/page.js": "1.3.7",
-    "visionmedia/debug": "2.1.0"
+    "visionmedia/page.js": "1.3.7"
   },
-  "locals": [ "request", "stateful", "jwt" ],
+  "locals": [
+    "request",
+    "stateful",
+    "jwt",
+    "debug"
+  ],
   "scripts": [ "citizen.js", "model.js" ],
   "templates": [ ],
   "styles": [ ],

--- a/lib/comment-card/component.json
+++ b/lib/comment-card/component.json
@@ -4,7 +4,7 @@
   "dependencies": {
     "component/dom": "0.7.1",
     "component/t": "1.0.0",
-    "visionmedia/debug": "0.7.4",
+    "visionmedia/debug": "2.1.0",
     "DemocracyOS/marked": "master"
   },
   "locals": [

--- a/lib/comment-card/component.json
+++ b/lib/comment-card/component.json
@@ -4,7 +4,6 @@
   "dependencies": {
     "component/dom": "0.7.1",
     "component/t": "1.0.0",
-    "visionmedia/debug": "2.1.0",
     "DemocracyOS/marked": "master"
   },
   "locals": [
@@ -14,7 +13,8 @@
     "config",
     "request",
     "comment-vote",
-    "view"
+    "view",
+    "debug"
   ],
   "scripts": [ "view.js" ],
   "templates": [ "template.jade" ],

--- a/lib/comment-vote/component.json
+++ b/lib/comment-vote/component.json
@@ -3,7 +3,6 @@
   "description": "Comment vote for generic comment view.",
   "dependencies": {
     "component/dom": "1.0.6",
-    "visionmedia/debug": "2.1.0",
     "component/t": "1.0.0"
   },
   "locals": [
@@ -11,7 +10,8 @@
     "citizen",
     "request",
     "config",
-    "render"
+    "render",
+    "debug"
   ],
   "scripts": [ "view.js" ],
   "styles" : [ "style.styl" ],

--- a/lib/comment-vote/component.json
+++ b/lib/comment-vote/component.json
@@ -2,9 +2,9 @@
   "name": "comment-vote",
   "description": "Comment vote for generic comment view.",
   "dependencies": {
-    "component/dom":"1.0.6",
-    "visionmedia/debug":"0.7.4",
-    "component/t":"1.0.0"
+    "component/dom": "1.0.6",
+    "visionmedia/debug": "2.1.0",
+    "component/t": "1.0.0"
   },
   "locals": [
     "view",

--- a/lib/comments-filter/component.json
+++ b/lib/comments-filter/component.json
@@ -4,13 +4,13 @@
   "dependencies": {
     "component/bus": "^0.0.2",
     "component/t": "1.0.0",
-    "component/closest": "0.1.4",
-    "visionmedia/debug": "2.1.0"
+    "component/closest": "0.1.4"
   },
   "locals": [
     "citizen",
     "store",
-    "view"
+    "view",
+    "debug"
   ],
   "styles": [ "styles.styl" ],
   "templates": [ "template.jade" ],

--- a/lib/comments-replies-edit/component.json
+++ b/lib/comments-replies-edit/component.json
@@ -9,13 +9,13 @@
     "component/t": "1.0.0",
     "slifszyc/query": "0.0.3",
     "jadejs/jade": "1.1.5",
-    "visionmedia/debug": "2.1.0",
     "yields/serialize": "0.2.0"
   },
   "locals": [
     "form-view",
     "render",
-    "request"
+    "request",
+    "debug"
   ],
   "scripts": [ "view.js" ],
   "styles" : [ "styles.styl" ],

--- a/lib/comments-replies/component.json
+++ b/lib/comments-replies/component.json
@@ -9,7 +9,6 @@
     "component/t": "1.0.0",
     "slifszyc/query": "0.0.3",
     "component/closest": "0.1.4",
-    "visionmedia/debug": "2.1.0",
     "jadejs/jade": "1.1.5",
     "yields/empty": "0.0.1",
     "yields/serialize": "0.2.0",
@@ -19,7 +18,8 @@
     "render",
     "request",
     "comments-replies-edit",
-    "stateful-view"
+    "stateful-view",
+    "debug"
   ],
   "styles": [ "comments-replies.styl" ],
   "scripts": [ "view.js" ],

--- a/lib/comments-view/component.json
+++ b/lib/comments-view/component.json
@@ -5,7 +5,7 @@
     "component/dom": "1.0.6",
     "component/t": "1.0.0",
     "slifszyc/loading-lock": "0867923281013c00b503c4bc866e103fd5024105",
-    "visionmedia/debug": "0.7.4"
+    "visionmedia/debug": "2.1.0"
   },
   "locals": [
     "citizen",

--- a/lib/comments-view/component.json
+++ b/lib/comments-view/component.json
@@ -4,8 +4,7 @@
   "dependencies": {
     "component/dom": "1.0.6",
     "component/t": "1.0.0",
-    "slifszyc/loading-lock": "0867923281013c00b503c4bc866e103fd5024105",
-    "visionmedia/debug": "2.1.0"
+    "slifszyc/loading-lock": "0867923281013c00b503c4bc866e103fd5024105"
   },
   "locals": [
     "citizen",
@@ -13,7 +12,8 @@
     "comment-card",
     "comments-filter",
     "form-view",
-    "request"
+    "request",
+    "debug"
   ],
   "scripts": [ "view.js" ],
   "styles": [ "styles.styl", "comments.styl" ],

--- a/lib/config/env.js
+++ b/lib/config/env.js
@@ -23,7 +23,7 @@ module.exports = {
     signinUrl: on(env.EXTERNAL_SIGNIN_URL, ''),
     signupUrl: on(env.EXTERNAL_SIGNUP_URL, '')
   },
-  client: env.CLIENT_CONF ? env.CLIENT_CONF.split(',') : [ "protocol", "host", "publicPort", "env", "locale", "logo", "favicon", "organization name", "organization url", "learn more url", "google analytics tracking id", "comments per page", "spam limit", "faq", "pp", "tos", "glossary", "authPages" ],
+  client: env.CLIENT_CONF ? env.CLIENT_CONF.split(',') : [ "protocol", "host", "publicPort", "env", "locale", "logo", "favicon", "organization name", "organization url", "learn more url", "google analytics tracking id", "comments per page", "spam limit", "faq", "pp", "tos", "glossary", "authPages", "debugging" ],
   auth: {
     basic: {
       username: env.BASIC_USERNAME,
@@ -63,5 +63,6 @@ module.exports = {
     port: on(env.HTTPS_PORT, 443),
     redirect: on(env.HTTPS_REDIRECT_MODE, 'normal'),
   },
-  multicore: on(env.MULTICORE)
+  multicore: on(env.MULTICORE),
+  debugging: on(env.DEBUGGING)
 };

--- a/lib/config/env.js
+++ b/lib/config/env.js
@@ -23,7 +23,7 @@ module.exports = {
     signinUrl: on(env.EXTERNAL_SIGNIN_URL, ''),
     signupUrl: on(env.EXTERNAL_SIGNUP_URL, '')
   },
-  client: env.CLIENT_CONF ? env.CLIENT_CONF.split(',') : [ "protocol", "host", "publicPort", "env", "locale", "logo", "favicon", "organization name", "organization url", "learn more url", "google analytics tracking id", "comments per page", "spam limit", "faq", "pp", "tos", "glossary", "authPages", "debugging" ],
+  client: env.CLIENT_CONF ? env.CLIENT_CONF.split(',') : [ "protocol", "host", "publicPort", "env", "locale", "logo", "favicon", "organization name", "organization url", "learn more url", "google analytics tracking id", "comments per page", "spam limit", "faq", "pp", "tos", "glossary", "authPages", "client debug" ],
   auth: {
     basic: {
       username: env.BASIC_USERNAME,
@@ -64,5 +64,5 @@ module.exports = {
     redirect: on(env.HTTPS_REDIRECT_MODE, 'normal'),
   },
   multicore: on(env.MULTICORE),
-  debugging: on(env.DEBUGGING)
+  "client debug": on(env.CLIENT_DEBUG)
 };

--- a/lib/debug/component.json
+++ b/lib/debug/component.json
@@ -1,0 +1,11 @@
+{
+  "name": "debug",
+  "dependencies": {
+    "visionmedia/debug": "2.1.0"
+  },
+  "locals": [
+    "config"
+  ],
+  "scripts": [ "index.js" ],
+  "main": "index.js"
+}

--- a/lib/debug/component.json
+++ b/lib/debug/component.json
@@ -1,10 +1,9 @@
 {
   "name": "debug",
-  "dependencies": {
-    "visionmedia/debug": "2.1.0"
-  },
+  "dependencies": { },
   "locals": [
-    "config"
+    "config",
+    "debug"
   ],
   "scripts": [ "index.js" ],
   "main": "index.js"

--- a/lib/debug/index.js
+++ b/lib/debug/index.js
@@ -1,0 +1,22 @@
+/**
+ * Module dependencies.
+ */
+
+var config = require('config');
+var debug = require('debug');
+
+/**
+ * Initialize debug
+ */
+
+if (config['client debug'] && true === config['client debug']) {
+  debug.disable();
+  debug.enable('democracyos:*');
+} else if (config['client debug'] && 'string' === typeof config['client debug']) {
+  debug.disable();
+  debug.enable(config['client debug']);
+} else {
+  debug.disable();
+}
+
+module.exports = debug;

--- a/lib/form-view/component.json
+++ b/lib/form-view/component.json
@@ -5,15 +5,15 @@
     "component/dom": "1.0.6",
     "component/inherit": "0.0.3",
     "component/spin": "0.0.2",
-    "component/t": "1.0.0",
-    "visionmedia/debug": "2.1.0"
+    "component/t": "1.0.0"
   },
   "locals": [
     "autosubmit",
     "autovalidate",
     "is-mobile",
     "validate",
-    "view"
+    "view",
+    "debug"
   ],
   "styles": [ "styles.styl" ],
   "scripts": [ "form-view.js" ],

--- a/lib/header/component.json
+++ b/lib/header/component.json
@@ -3,7 +3,6 @@
   "description": "header component",
   "dependencies": {
     "component/dom": "1.0.6",
-    "visionmedia/debug": "2.1.0",
     "jadejs/jade": "1.1.5",
     "democracyos/headroom.js": "0.7.1"
     },
@@ -13,7 +12,8 @@
     "snapper",
     "user-badge",
     "view",
-    "is-mobile"
+    "is-mobile",
+    "debug"
   ],
   "scripts": [
     "index.js",

--- a/lib/homepage/component.json
+++ b/lib/homepage/component.json
@@ -4,7 +4,6 @@
   "dependencies": {
     "component/bus": "^0.0.2",
     "component/dom": "0.7.1",
-    "visionmedia/debug": "2.1.0",
     "visionmedia/page.js": "1.3.7",
     "jadejs/jade": "1.1.5",
     "component/t": "1.0.0"
@@ -13,7 +12,8 @@
   "locals": [
     "citizen",
     "sidebar",
-    "render"
+    "render",
+    "debug"
   ],
   "scripts": [
     "homepage.js"

--- a/lib/law/component.json
+++ b/lib/law/component.json
@@ -4,7 +4,6 @@
   "dependencies": {
     "component/classes": "1.2.0",
     "component/bus": "^0.0.2",
-    "visionmedia/debug": "2.1.0",
     "visionmedia/page.js": "1.3.7",
     "yields/empty": "0.0.1",
     "slifszyc/query": "0.0.3"
@@ -18,7 +17,8 @@
     "proposal-article",
     "proposal-options",
     "comments-view",
-    "browser-lock"
+    "browser-lock",
+    "debug"
   ],
   "scripts": [ "law.js" ],
   "styles": [ ],

--- a/lib/laws-filter/component.json
+++ b/lib/laws-filter/component.json
@@ -3,7 +3,6 @@
   "description": "Filter for laws. Saves state in session or localStorage if availble",
   "dependencies": {
     "component/emitter": "1.1.3",
-    "visionmedia/debug": "2.1.0",
     "cristiandouce/merge-util": "0.2.0",
     "component/t": "1.0.0",
     "component/type": "1.0.0",
@@ -13,7 +12,8 @@
     "citizen",
     "laws",
     "store",
-    "stateful"
+    "stateful",
+    "debug"
   ],
   "scripts": [ "laws-filter.js", "sorts.js" ],
   "main": "laws-filter.js"

--- a/lib/laws/component.json
+++ b/lib/laws/component.json
@@ -2,14 +2,14 @@
   "name": "laws",
   "description": "Collection of laws",
   "dependencies": {
-    "component/emitter": "1.1.3",
-    "visionmedia/debug": "2.1.0"
+    "component/emitter": "1.1.3"
   },
   "locals": [
     "citizen",
     "request",
     "render",
-    "stateful"
+    "stateful",
+    "debug"
   ],
   "scripts": [
     "laws.js",

--- a/lib/logout/component.json
+++ b/lib/logout/component.json
@@ -3,10 +3,12 @@
   "description": "header component",
   "dependencies": {
     "component/bus": "^0.0.2",
-    "visionmedia/page.js": "1.3.7",
-    "visionmedia/debug": "2.1.0"
-    },
-  "locals": [ "request" ],
+    "visionmedia/page.js": "1.3.7"
+  },
+  "locals": [
+    "request",
+    "debug"
+  ],
   "scripts": [ "logout.js" ],
   "styles": [ ],
   "templates": [ ],

--- a/lib/proposal-clauses/component.json
+++ b/lib/proposal-clauses/component.json
@@ -3,15 +3,15 @@
   "description": "proposal's clauses view",
   "dependencies": {
     "component/t": "1.0.0",
-    "jadejs/jade": "1.1.5",
-    "visionmedia/debug": "2.1.0"
+    "jadejs/jade": "1.1.5"
   },
   "locals": [
     "config",
     "citizen",
     "side-comments",
     "request",
-    "stateful-view"
+    "stateful-view",
+    "debug"
   ],
   "scripts": [ "proposal-clauses.js" ],
   "templates": [ "template.jade" ],

--- a/lib/proposal-options/component.json
+++ b/lib/proposal-options/component.json
@@ -4,13 +4,18 @@
   "dependencies": {
     "component/dom": "1.0.6",
     "component/bus": "^0.0.2",
-    "visionmedia/debug": "2.1.0",
     "visionmedia/page.js": "1.3.7",
     "cristiandouce/Chart.js": "eef51",
     "component/t": "1.0.0",
     "component/closest": "0.1.4"
   },
-  "locals": [ "citizen", "request", "render", "view" ],
+  "locals": [
+    "citizen",
+    "request",
+    "render",
+    "view",
+    "debug"
+  ],
   "scripts": [ "proposal-options.js" ],
   "templates": [
     "template.jade",

--- a/lib/proposal/component.json
+++ b/lib/proposal/component.json
@@ -2,7 +2,6 @@
   "name": "proposal",
   "description": "proposal pages",
   "dependencies": {
-    "visionmedia/debug": "2.1.0",
     "visionmedia/page.js": "1.3.7",
     "yields/empty": "0.0.1"
   },
@@ -12,7 +11,8 @@
     "sidebar",
     "proposal-article",
     "proposal-options",
-    "comments-view"
+    "comments-view",
+    "debug"
   ],
   "scripts": [ "proposal.js" ],
   "styles": [ ],

--- a/lib/request/component.json
+++ b/lib/request/component.json
@@ -4,11 +4,11 @@
   "version": "0.0.1",
   "dependencies": {
     "component/bus": "^0.0.2",
-    "visionmedia/debug": "2.1.0",
     "visionmedia/superagent": "0.16.0"
   },
   "locals": [
-    "jwt"
+    "jwt",
+    "debug"
   ],
   "scripts": [ "request.js" ],
   "main": "request.js"

--- a/lib/settings-notifications/component.json
+++ b/lib/settings-notifications/component.json
@@ -2,13 +2,13 @@
   "name": "settings-notifications",
   "description": "Settings notifications view",
   "dependencies": {
-    "component/t": "1.0.0",
-    "visionmedia/debug": "2.1.0"
+    "component/t": "1.0.0"
   },
   "locals": [
     "citizen",
     "form-view",
-    "toggle"
+    "toggle",
+    "debug"
   ],
   "templates": [
     "template.jade"

--- a/lib/settings-password/component.json
+++ b/lib/settings-password/component.json
@@ -3,11 +3,11 @@
   "description": "Settings password view",
   "dependencies": {
     "jadejs/jade": "1.1.5",
-    "visionmedia/debug": "2.1.0",
     "component/t": "1.0.0"
   },
   "locals": [
-    "form-view"
+    "form-view",
+    "debug"
   ],
   "templates": [
     "template.jade"

--- a/lib/settings-profile/component.json
+++ b/lib/settings-profile/component.json
@@ -2,13 +2,13 @@
   "name": "settings-profile",
   "description": "Settings profile view",
   "dependencies": {
-    "visionmedia/debug": "2.1.0",
     "jadejs/jade": "1.1.5",
     "component/t": "1.0.0"
   },
   "locals": [
     "citizen",
-    "form-view"
+    "form-view",
+    "debug"
   ],
   "templates": [
     "template.jade"

--- a/lib/sidebar/component.json
+++ b/lib/sidebar/component.json
@@ -8,7 +8,6 @@
     "component/bus": "^0.0.2",
     "component/emitter": "1.1.3",
     "component/classes": "1.2.0",
-    "visionmedia/debug": "2.1.0",
     "jadejs/jade": "1.1.5",
     "yields/empty": "0.0.1",
     "component/closest": "0.1.4",
@@ -16,7 +15,15 @@
     "component/t": "1.0.0",
     "slifszyc/query": "0.0.3"
   },
-  "locals": [ "citizen", "laws", "laws-filter", "render", "stateful-view", "view" ],
+  "locals": [
+    "citizen",
+    "laws",
+    "laws-filter",
+    "render",
+    "stateful-view",
+    "view",
+    "debug"
+  ],
   "scripts": [ "main.js", "sidebar.js", "filter.js", "list.js" ],
   "templates": [ "sidebar-container.jade", "list-item.jade", "filter-item.jade", "filter-container.jade", "list-container.jade", "check.jade" ],
   "styles": [ "sidebar.styl" ],

--- a/lib/stateful/component.json
+++ b/lib/stateful/component.json
@@ -2,10 +2,12 @@
   "name": "stateful",
   "description": "Give states to a protoype",
   "dependencies": {
-    "visionmedia/debug": "2.1.0",
     "component/emitter": "1.1.3",
     "kewah/mixin": "0.1.0"
   },
+  "locals": [
+    "debug"
+  ],
   "scripts": ["stateful.js"],
   "main": "stateful.js"
 }

--- a/lib/tags/component.json
+++ b/lib/tags/component.json
@@ -2,13 +2,13 @@
   "name": "tags",
   "description": "Collection of tags",
   "dependencies": {
-    "component/emitter": "1.1.3",
-    "visionmedia/debug": "2.1.0"
+    "component/emitter": "1.1.3"
   },
   "locals": [
     "request",
     "render",
-    "stateful"
+    "stateful",
+    "debug"
   ],
   "scripts": [
     "tags.js",

--- a/lib/validate/component.json
+++ b/lib/validate/component.json
@@ -2,11 +2,11 @@
   "name": "validate",
   "description": "Validate fields and display messages",
   "dependencies": {
-    "component/dom": "1.0.6",
-    "visionmedia/debug": "2.1.0"
+    "component/dom": "1.0.6"
   },
   "locals": [
-    "validators"
+    "validators",
+    "debug"
   ],
   "scripts": [ "validate.js" ],
   "main": "validate.js"

--- a/lib/validators/component.json
+++ b/lib/validators/component.json
@@ -4,10 +4,12 @@
   "dependencies": {
     "component/assert": "0.4.0",
     "component/dom": "1.0.6",
-    "component/t": "1.0.0",
-    "visionmedia/debug": "2.1.0"
+    "component/t": "1.0.0"
   },
-  "locals": [ "regexps" ],
+  "locals": [
+    "regexps",
+    "debug"
+  ],
   "scripts": [ "validators.js" ],
   "main": "validators.js"
 }

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "component-resolver": "1.2.4",
     "component-stylus-plugin": "~0.3.1",
     "connect-mongo": "~0.4.0",
-    "debug": "~0.7.4",
+    "debug": "^2.1.1",
     "express": "~3.4.7",
     "express-sslify": "0.1.1",
     "http-auth": "1.3.0",


### PR DESCRIPTION
This adds the possibility to configure the debugging scopes on client side.

Have to add to `environment.json`:
```
"client": ["client debug"],
"client debug": true,
```
Possible values for `"client debug"`:
* `false`: Disable debugging
* `true`: Will debug everything on "democracyos:*"
* {String}: Scope to debug, e.g. `democracyos:citizen`