### PR TITLE
[setup/user] update usage of mongodb by adding the db module

### DIFF
--- a/lib/db/index.js
+++ b/lib/db/index.js
@@ -1,0 +1,92 @@
+/**
+ * Module dependencies.
+ */
+
+var mongoose = require('mongoose');
+var log = require('debug')('democracyos:db');
+
+/**
+ * Connects to the databse and returns the connection
+ * @param  {string} uri mongoDB-compliant connection URI
+ * @param  {Object} opts additional options:
+ *                       createConnection {Boolean|false} connect to a database that's not the default one
+ *                       rsName {String|'rs0'} replica set name
+ *                       verbose {Boolean|false} log mongoose connection status verbosely
+ * @return {Mixed} new connection if createConnection is true, `mongoose` instance otherwise
+ */
+exports.connect = function connect (uri, opts) {
+  opts = opts || { createConnection: false, rsName: 'rs0', verbose: false };
+
+  var dbOptions = defaultOptions();
+
+  // Is it a replica set connection string?
+  if (!!~uri.indexOf(',')) {
+
+    dbOptions.db.w = 'majority';
+
+    dbOptions.replSet = {
+      haInterval: 500,
+      reconnectWait: 5000,
+      poolSize: 5,
+      retries: 10000000,
+      readPreference: 'secondaryPreferred',
+      rs_name: opts.rsName,
+      socketOptions: {
+        connectTimeoutMS: 5000,
+        keepAlive: 1
+      }
+    }
+  };
+
+  setupListeners(uri, opts.verbose);
+
+  return opts.createConnection ? mongoose.createConnection(uri, dbOptions) : mongoose.connect(uri, dbOptions);
+};
+
+function defaultOptions() {
+  return {
+    db: {
+      journal: true,
+      retryMiliSeconds: 5000,
+      numberOfRetries: Number.MAX_VALUE,
+      readPreference: 'secondaryPreferred'
+    },
+    auto_reconnect: true,
+    server: {
+      poolSize: 5,
+      auto_reconnect: true,
+      socketOptions: {
+        connectTimeoutMS: 5000,
+        keepAlive: 1
+      }
+    }
+  };
+}
+
+function setupListeners(uri, verbose) {
+  mongoose.connection.on('error', function (err) {
+    log('ERROR: in mongoose connection %s : %s', uri, err);
+  });
+
+  mongoose.connection.on('disconnected', function (err) {
+    log('WARNING: mongoose disconnected from %s - Error: %s', uri, err);
+  });
+
+  if (verbose) {
+    mongoose.connection.on('reconnect', function() {
+      log('Mongoose reconnecting to %s', uri);
+    });
+
+    mongoose.connection.on('connected', function() {
+      log('Mongoose connected to %s', uri);
+    });
+
+    mongoose.connection.on('connecting', function() {
+      log('Mongoose connecting to %s', uri);
+    });
+
+    mongoose.connection.on('open', function() {
+      log('Mongoose connection open to %s', uri);
+    });
+  }
+};

--- a/lib/models/user.js
+++ b/lib/models/user.js
@@ -3,14 +3,19 @@
  */
 
 var config = require('lib/config');
+var db = require('lib/db');
 var mongoose = require('mongoose');
-var mongoUrl = config('mongoUsersUrl') || config('mongoUrl');
-var conn = mongoose.createConnection(mongoUrl);
-var Schema = mongoose.Schema;
-var ObjectId = Schema.ObjectId;
 var passportLocalMongoose = require('passport-local-mongoose');
 var gravatar = require('mongoose-gravatar');
 var regexps = require('lib/regexps');
+
+
+var Schema = mongoose.Schema;
+var ObjectId = Schema.ObjectId;
+
+var mongoUsersUrl = config('mongoUsersUrl');
+var mongoUrl = mongoUsersUrl || config('mongoUrl');
+var conn = db.connect(mongoUrl, { createConnection: !!mongoUsersUrl });
 
 /**
  * Define `User` Schema

--- a/lib/setup/index.js
+++ b/lib/setup/index.js
@@ -6,7 +6,7 @@ var express = require('express');
 var passport = require('passport');
 var nowww = require('nowww');
 var log = require('debug')('setup');
-var mongoose = require('mongoose');
+var db = require('lib/db');
 var resolve = require('path').resolve;
 var config = require('lib/config');
 var auth = require('http-auth');
@@ -34,7 +34,7 @@ function Setup(app) {
    *  Connect to mongo
    */
 
-  mongoose.connect(config('mongoUrl'), { db: { safe: true }});
+  db.connect(config('mongoUrl'));
 
 
   /**


### PR DESCRIPTION
Allows properly using MongoDB replica sets. App recognizes setting from mongo URI and self-configures accordingly.

Only tested this by setting just `mongoUrl` or both `mongoUrl` and `mongoUsersUrl` to databases of the same kind (single + single / replSet + replSet).

Haven't tested it with the following hybrid setups: `mongoUrl` pointing to a single database and `mongoUsersUrl` pointing to a replicaSet, or viceversa. 