### PR TITLE
Add create my first debate button for staff members Closes #703

### DIFF
--- a/lib/homepage/component.json
+++ b/lib/homepage/component.json
@@ -18,7 +18,7 @@
   "scripts": [
     "homepage.js"
   ],
-  "templates": [ "no-laws.jade" ],
+  "templates": [ "no-laws.jade", "create-first-law.jade" ],
   "styles": [ "homepage.styl" ],
   "main": "homepage.js"
 }

--- a/lib/homepage/create-first-law.jade
+++ b/lib/homepage/create-first-law.jade
@@ -1,0 +1,2 @@
+a.btn.btn-primary.btn-lg.btn-block.create-first-law(type='button')
+  = t('homepage.create-debate')

--- a/lib/homepage/homepage.js
+++ b/lib/homepage/homepage.js
@@ -5,11 +5,12 @@
 var page = require('page');
 var sidebar = require('sidebar');
 var o = require('dom');
-var t = require('t');
 var render = require('render');
 var noLaws = require('./no-laws');
+var createFirstLaw = require('./create-first-law');
 var bus = require('bus');
 var log = require('debug')('democracyos:homepage');
+var citizen = require('citizen');
 
 // Routing.
 page('/', sidebarready, function(ctx, next) {
@@ -17,13 +18,23 @@ page('/', sidebarready, function(ctx, next) {
 
   var law = sidebar.items(0);
 
+  var pageChanged = false;
   function onpagechange() {
+    pageChanged = true;
     o(document.body).removeClass('browser-page');
   }
 
   if (!law) {
+    var content = o('#browser .app-content');
     var el = render.dom(noLaws);
-    o('#browser .app-content').empty().append(el);
+    content.empty().append(el);
+    citizen.ready(function(){
+      if (pageChanged) return;
+      if (citizen.staff) {
+        var el = render.dom(createFirstLaw);
+        content.append(el);
+      }
+    });
     bus.once('page:change', onpagechange);
     return bus.emit('page:render');
   }

--- a/lib/homepage/homepage.styl
+++ b/lib/homepage/homepage.styl
@@ -1,8 +1,20 @@
 .no-laws
-  background: #909FA0
-  margin: 50px auto
-  width: 50%
+  margin 90px auto
+  width 70%
+  color #333
+  font-weight 500
+
+.browser-page
+  .create-first-law
+    margin 50px auto
+    width 65%
+    padding-top .8em
+    padding-bottom .6em
+    border-radius 3px
+    text-transform none
+    font-size 1em
 
 @media only screen and (max-width: 700px)
-  .no-laws
-    width: 90%
+  .no-laws,
+  .create-first-law
+    width 90%

--- a/lib/homepage/no-laws.jade
+++ b/lib/homepage/no-laws.jade
@@ -1,1 +1,1 @@
-.alert.no-laws.text-center= t('homepage.no-laws')
+h4.no-laws.text-center= t('homepage.no-laws')

--- a/lib/translations/lib/ca.json
+++ b/lib/translations/lib/ca.json
@@ -148,6 +148,7 @@
   "help.pp.title": "Política de Privacitat",
   "help.title": "Ajut",
   "help.tos.title": "Termes de Servei",
+  "homepage.create-debate": "Crear el meu primer debat",
   "homepage.no-laws": "No hi ha lleis per mostrar",
   "invalid.password": "contrasenya no vàlida",
   "markdown.cheatsheet.title": "Ajuda de format",

--- a/lib/translations/lib/de.json
+++ b/lib/translations/lib/de.json
@@ -148,6 +148,7 @@
   "help.pp.title": "Datenschutzbestimmungen",
   "help.title": "Hilfe",
   "help.tos.title": "AGB",
+  "homepage.create-debate": "Erstelle meine erste Debatte",
   "homepage.no-laws": "Gibt es keine Themen angezeigt",
   "invalid.password": "Invalid password",
   "markdown.cheatsheet.title": "Bearbeitungshilfe",

--- a/lib/translations/lib/en.json
+++ b/lib/translations/lib/en.json
@@ -148,6 +148,7 @@
   "help.pp.title": "Privacy Policy",
   "help.title": "Help",
   "help.tos.title": "Terms of Service",
+  "homepage.create-debate": "Create my first debate",
   "homepage.no-laws": "There are no topics to display",
   "invalid.password": "Invalid password",
   "markdown.cheatsheet.title": "Formatting help",

--- a/lib/translations/lib/es.json
+++ b/lib/translations/lib/es.json
@@ -148,6 +148,7 @@
   "help.pp.title": "Política de privacidad",
   "help.title": "Ayuda",
   "help.tos.title": "Términos y condiciones",
+  "homepage.create-debate": "Crear mi primer debate",
   "homepage.no-laws": "No hay leyes para mostrar",
   "invalid.password": "Contraseña no válida",
   "markdown.cheatsheet.title": "Ayuda de edición",

--- a/lib/translations/lib/fi.json
+++ b/lib/translations/lib/fi.json
@@ -148,6 +148,7 @@
   "help.pp.title": "Yksityisyyden suoja",
   "help.title": "Apu",
   "help.tos.title": "Käyttöehdot",
+  "homepage.create-debate": "Luo ensimmäinen keskustelu",
   "homepage.no-laws": "Ei ole lakeja näytettäviä",
   "invalid.password": "Virheellinen salasana",
   "markdown.cheatsheet.title": "Markdown-ohjeet",

--- a/lib/translations/lib/fr.json
+++ b/lib/translations/lib/fr.json
@@ -148,6 +148,7 @@
   "help.pp.title": "Politique de confidentialité",
   "help.title": "Assistance",
   "help.tos.title": "Conditions d'Utilisation",
+  "homepage.create-debate": "Créer mon premier débat",
   "homepage.no-laws": "Il n'y a pas de lois à afficher",
   "invalid.password": "mot de passe invalide",
   "markdown.cheatsheet.title": "Formatage aide",

--- a/lib/translations/lib/gl.json
+++ b/lib/translations/lib/gl.json
@@ -148,6 +148,7 @@
   "help.pp.title": "Política de privacidade",
   "help.title": "Axuda",
   "help.tos.title": "Condicións de servizo",
+  "homepage.create-debate": "Crear o meu primeiro debate",
   "homepage.no-laws": "Non hai leis para mostrar",
   "invalid.password": "Contrasinal non válido",
   "markdown.cheatsheet.title": "Axuda de edición",

--- a/lib/translations/lib/it.json
+++ b/lib/translations/lib/it.json
@@ -148,6 +148,7 @@
   "help.pp.title": "Norme sulla privacy",
   "help.title": "Aiuto",
   "help.tos.title": "Termini di servizio",
+  "homepage.create-debate": "Creare il mio primo dibattito",
   "homepage.no-laws": "Non ci sono leggi da mostrare",
   "invalid.password": "Password non valida",
   "markdown.cheatsheet.title": "Guida da aiutare edizione",

--- a/lib/translations/lib/nl.json
+++ b/lib/translations/lib/nl.json
@@ -148,6 +148,7 @@
   "help.pp.title": "Privacy beleid",
   "help.title": "HULP",
   "help.tos.title": "Gebruikersvoorwaarden",
+  "homepage.create-debate": "Maak mijn eerste debat",
   "homepage.no-laws": "Er zijn geen wetten om te laten zien",
   "invalid.password": "Ongeldig wachtwoord",
   "markdown.cheatsheet.title": "Hulp bij opmaak",

--- a/lib/translations/lib/pt.json
+++ b/lib/translations/lib/pt.json
@@ -148,6 +148,7 @@
   "help.pp.title": "Política de Privacidade",
   "help.title": "Ajuda",
   "help.tos.title": "Termos de Serviço",
+  "homepage.create-debate": "Criar meu primeiro debate",
   "homepage.no-laws": "Não existem projetos para mostrar",
   "invalid.password": "Senha inválida",
   "markdown.cheatsheet.title": "Ajuda de edição",

--- a/lib/translations/lib/ru.json
+++ b/lib/translations/lib/ru.json
@@ -148,6 +148,7 @@
   "help.pp.title": "Помочь проекту",
   "help.title": "Главная",
   "help.tos.title": "Условия пользования",
+  "homepage.create-debate": "Создать мой первый дебаты",
   "homepage.no-laws": "Нет законов для голосования",
   "invalid.password": "Неверный пароль",
   "markdown.cheatsheet.title": "Помощь с форматированием",

--- a/lib/translations/lib/sv.json
+++ b/lib/translations/lib/sv.json
@@ -148,6 +148,7 @@
   "help.pp.title": "Säkerhetspolicy",
   "help.title": "Hjälp",
   "help.tos.title": "Användarvillkor",
+  "homepage.create-debate": "Skapa mitt första debatten",
   "homepage.no-laws": "Det finns inga lagar att visa",
   "invalid.password": "Ogiltigt lösenord",
   "markdown.cheatsheet.title": "Formattingshjälp",

--- a/lib/translations/lib/uk.json
+++ b/lib/translations/lib/uk.json
@@ -148,6 +148,7 @@
   "help.pp.title": "Допомогти проекту",
   "help.title": "Головна",
   "help.tos.title": "Умови користування",
+  "homepage.create-debate": "Створити мій перший дебати",
   "homepage.no-laws": "Немає законів для голосування",
   "invalid.password": "Невірний пароль",
   "markdown.cheatsheet.title": "Допомога з форматуванням",


### PR DESCRIPTION
*2 things to notice:*
+ Had to change the styling of the "There are no topics to display" alert, because it looked like a button and was competing (and its not a button).
+ We're not being consistent with the wording, the button says "debate" and the alert says "topics".

![captura de pantalla 2015-03-13 a las 11 03 30](https://cloud.githubusercontent.com/assets/558901/6639785/3f889b44-c971-11e4-9407-ccb2d60dc811.png)
