### PR TITLE
Changes comment-text anchor text to inline #715

### DIFF
--- a/lib/comment-card/styles.styl
+++ b/lib/comment-card/styles.styl
@@ -113,7 +113,7 @@
     p
       margin-bottom 0
     a
-      display inline-block
+      display inline
       margin-bottom 12px
 
   .oncomment,


### PR DESCRIPTION
Fixes #715 where comments link text should line break as regular text. 