### PR TITLE
Fixes #717 typos in must be signed in text

### DIFF
--- a/lib/proposal-options/template.jade
+++ b/lib/proposal-options/template.jade
@@ -40,9 +40,9 @@
 
         - if (!citizen.id)
           p.text-mute.overlay-vote.hide= t('proposal-options.must-be-signed-in')
-            | .
+            | .&nbsp;
             a(href="/signin")= t('signin.login')
-            |  #{t('common.or')}
+            |  #{t('common.or')}&nbsp;
             a(href="/signup?reference=" + proposal.id)= t('signin.signup')
             | .
 


### PR DESCRIPTION
Adds non breaking white space to the end of the period and " or".  Closes #717 