### PR TITLE
Fix broken spinner after signin

### DIFF
--- a/lib/browser-lock/locker.js
+++ b/lib/browser-lock/locker.js
@@ -3,8 +3,21 @@
  */
 
 var loading = require('loading-lock');
+var proto = loading.prototype;
+var lock = proto.lock;
+var unlock = proto.unlock;
 var bus = require('bus');
 var o = require('query');
+
+loading.prototype.lock = function() {
+  this.locked = true;
+  lock.call(this);
+};
+
+loading.prototype.unlock = function() {
+  if (this.locked) unlock.call(this);
+  this.locked = false;
+};
 
 module.exports = exports = loading(o('#browser'), { size: 80 });
 


### PR DESCRIPTION
I could reproduce the issue by signin in and try to change law in sidebar. 
In `browser-lock` we are using a singleton instance of `cristiandouce/loading-lock` and in certain cases that instance is being unlocked twice, then crashes trying to remove a DOM element that no longer exists.
I added a wrapper in order to put a flag that indicates the state (`locked`/`unlocked`) and during `unlock` it checks that flag before trying to modify the DOM.
Closes #738.