### PR TITLE
Mods for DemocracyOS to run on Windows

### DIFF
--- a/lib/translations/index.js
+++ b/lib/translations/index.js
@@ -1,7 +1,7 @@
 var fs = require('fs');
 var path = require('path');
 
-var locales = fs.readdirSync(path.resolve(__dirname, '/lib')).map(function(v){
+var locales = fs.readdirSync(path.resolve(__dirname, 'lib')).map(function(v){
   return v.replace('.json', '');
 });
 

--- a/make.cmd
+++ b/make.cmd
@@ -1,0 +1,57 @@
+@echo off
+
+rem
+rem DemocracyOS Makefile emulation for Windows
+rem
+
+if DEBUG == "" set DEBUG=democracyos:*
+
+if NODE_ENV == "" set NODE_ENV="development"
+
+if not "%1" == "run" goto packages
+if exist INSTALLED goto run
+
+echo Installing dependencies...
+call npm install
+echo INSTALLED >INSTALLED
+echo.
+if errorlevel 0 echo Installed !
+echo.
+:run
+echo Starting application...
+set NODE_PATH=.
+set DEBUG=%DEBUG%
+call node index.js
+goto end
+
+:packages
+if not "%1" == "packages" goto clean
+echo Installing dependencies...
+call npm install
+echo INSTALLED >INSTALLED
+echo.
+if errorlevel 0 echo Installed !
+echo.
+goto end
+
+:clean
+if not "%1" == "clean" goto help
+echo Removing dependencies, components and built assets.
+rd /S/Q node_modules
+rd /S/Q components
+rd /S/Q public
+del INSTALLED
+echo Done !
+goto end
+
+:help
+
+echo.
+echo make [command]
+echo.
+echo     packages
+echo     run
+echo     clean
+echo.
+
+:end


### PR DESCRIPTION
There are two modes one adds make.cmd which emulates the Makefile behaviour.

The other is a hack to fix path.resolve, this seems to effect both Linux and MacOSX as well.