### PR TITLE
Fix `component/confirmation` styles and breaking `focus()` calling

### DIFF
--- a/lib/admin-laws-form/view.js
+++ b/lib/admin-laws-form/view.js
@@ -181,7 +181,6 @@ LawForm.prototype.onremoveclauseclick = function(ev) {
   .modal()
   .closable()
   .effect('slide')
-  .focus()
   .show(onconfirm.bind(this))
 
   function onconfirm(ok) {
@@ -238,7 +237,6 @@ LawForm.prototype.onremovelinkclick = function(ev) {
   .modal()
   .closable()
   .effect('slide')
-  .focus()
   .show(onconfirm.bind(this))
 
   function onconfirm(ok) {
@@ -372,7 +370,6 @@ LawForm.prototype.ondeletelawclick = function(ev) {
   .modal()
   .closable()
   .effect('slide')
-  .focus()
   .show(onconfirmdelete.bind(this))
 
   function onconfirmdelete(ok) {

--- a/lib/admin-laws/view.js
+++ b/lib/admin-laws/view.js
@@ -59,7 +59,6 @@ LawsListView.prototype.ondeletelawclick = function(ev) {
     .modal()
     .closable()
     .effect('slide')
-    .focus()
     .show(onconfirmdelete.bind({ lawId: lawId, el: el }));
 
   function onconfirmdelete(ok) {

--- a/lib/boot/boot.styl
+++ b/lib/boot/boot.styl
@@ -302,12 +302,12 @@ body
   .overlay
     background radial-gradient(ellipse at center, rgba(0,0,0,0.25) 0%, rgba(0,0,0,0.55) 100%)
     z-index 9999998
-  #dialog
+  .dialog.confirmation
     position fixed
     display block
     max-width 500px
     min-width 250px
-    left 50%
+    left 32%
     top 150px
     right initial
     bottom initial
@@ -320,7 +320,7 @@ body
       font-size 1.1em
     .content
       padding 0px 20px 10px 20px
-      margin-top 30px
+      width 100% // overrides .dialog width from dialog component
       .title
         position absolute
         left 0px
@@ -334,7 +334,7 @@ body
         font-weight 600
       .body
         padding 20px 0px
-        // margin-top 30px
+        margin-top 30px
       .close
         line-height 10px
         top 10px


### PR DESCRIPTION
Closes #838.