### PR TITLE
Small fix to Spanish translation

### DIFF
--- a/lib/translations/lib/es.json
+++ b/lib/translations/lib/es.json
@@ -276,7 +276,7 @@
   "signup.being-redirected": "En 5 segundos serás redirigido",
   "signup.browsing": "comenzar",
   "signup.check-email": "El siguiente paso es abrir el correo electrónico que te hemos enviado (no te olvides de la carpeta 'Correo no deseado') y hacer clic en el enlace suministrado.",
-  "signup.complete": "Registración finalizada",
+  "signup.complete": "Registro finalizado",
   "signup.email": "Correo electrónico",
   "signup.email-sent": "Correo electrónico enviado",
   "signup.email-validated": "Tu correo electrónico ha sido validado y has ingresado a tu cuenta",


### PR DESCRIPTION
The word "Registración" does not exist in Spanish. "Registro" is the right translation.