### PR TITLE
Added LiveReload

### DIFF
--- a/lib/build/css.js
+++ b/lib/build/css.js
@@ -8,6 +8,7 @@ var sourcemaps = require('gulp-sourcemaps');
 var addsrc = require('gulp-add-src');
 var gulpif = require('gulp-if');
 var Log = require('./log');
+var livereload = require('gulp-livereload');
 
 module.exports = {
 
@@ -20,7 +21,8 @@ module.exports = {
       .pipe(gulpif(settings.sourcemaps, sourcemaps.write()))
       .pipe(concat('app.css'))
       .pipe(gulpif(settings.minify, minify()))
-      .pipe(gulp.dest(settings.public));
+      .pipe(gulp.dest(settings.public))
+      .pipe(gulpif(settings.livereload, livereload({ start: true })));
   },
 
   lint: function () {

--- a/lib/build/js.js
+++ b/lib/build/js.js
@@ -10,6 +10,7 @@ var jshint = require('gulp-jshint');
 var watchify = require('watchify');
 var gulpif = require('gulp-if');
 var Log = require('./log');
+var livereload = require('gulp-livereload');
 
 var opts = {
   debug: settings.sourcemaps,
@@ -35,7 +36,8 @@ function bundle(b) {
     .pipe(source('app.js'))
     .pipe(buffer())
     .pipe(gulpif(settings.minify, uglify()))
-    .pipe(gulp.dest(settings.public));
+    .pipe(gulp.dest(settings.public))
+    .pipe(gulpif(settings.livereload, livereload({ start: true })));
 }
 
 /*
@@ -66,7 +68,8 @@ module.exports = {
       .pipe(source('app.js'))
       .pipe(buffer())
       .pipe(gulpif(settings.minify, uglify()))
-      .pipe(gulp.dest(settings.public));
+      .pipe(gulp.dest(settings.public))
+      .pipe(gulpif(settings.livereload, livereload({ start: true })));
     });
 
     w.on('log', function (msg) {

--- a/lib/build/settings.js
+++ b/lib/build/settings.js
@@ -9,5 +9,6 @@ settings.verbose = !!argv.verbose;
 settings.sourcemaps = !production && argv.sourcemaps;
 settings.minify = !production && argv.minify;
 settings.production = production;
+settings.livereload = !production && argv.livereload;
 
 module.exports = settings;

--- a/package.json
+++ b/package.json
@@ -147,7 +147,8 @@
     "nanomodal": "5.1.1",
     "watchify": "3.2.1",
     "yargs": "3.9.1",
-    "gulp-if": "1.2.5"
+    "gulp-if": "1.2.5",
+    "gulp-livereload": "3.8.0"
   },
   "browser": {
     "closest": "component-closest",


### PR DESCRIPTION
Can be enabled using `--livereload` flag to the `gulp watch` command.
Requires a LiveReload client, like [this extension for Chrome](https://chrome.google.com/webstore/detail/livereload/jnihajbhpnppcggbcgedagnkighmdlei).