### PR TITLE
[homepage] - Fix showing multiple times the same button. Close #955

### DIFF
--- a/lib/homepage/homepage.js
+++ b/lib/homepage/homepage.js
@@ -38,11 +38,9 @@ function singleForum(ctx, next) {
   if (!topic) {
     let content = o('#browser .app-content');
     content.empty().append(dom(noTopics));
-    user.ready(() => {
-      if (!pageChanged && user.staff) {
-        content.append(dom(createFirstTopic));
-      }
-    });
+    if (user.staff) {
+      content.append(dom(createFirstTopic));
+    }
     bus.once('page:change', () => {
       pageChanged = true;
       body.removeClass('browser-page');


### PR DESCRIPTION
Checking for `user.ready` (unncesary) was removed due to the `user.optional` middleware.

Either way button was not displaying multiple times