### PR TITLE
Support node 4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -158,7 +158,7 @@
     "gulp-eslint": "0.13.0",
     "eslint": "0.22.1",
     "verigy": "2.0.1",
-    "jsdom": "3.1.2",
+    "jsdom": "6.3.0",
     "democracyos-wrap": "~0.0.2",
     "xss": "0.2.2"
   },

--- a/package.json
+++ b/package.json
@@ -170,8 +170,8 @@
   },
   "main": "pdr",
   "engines": {
-    "node": "0.12.4",
-    "npm": "2.10.1"
+    "node": "4.0.0",
+    "npm": "2.14.2"
   },
   "browserify": {
     "transform": [


### PR DESCRIPTION
Update dependency `jsdom` and `engines` so we can run in `node 4.0.0`